### PR TITLE
Sort the translations before exporting to a file as json

### DIFF
--- a/lib/i18n-js.rb
+++ b/lib/i18n-js.rb
@@ -119,6 +119,7 @@ module SimplesIdeias
     def save(translations, file)
       file = Rails.root.join(file)
       FileUtils.mkdir_p File.dirname(file)
+      translations = Hash[translations.sort]
 
       File.open(file, "w+") do |f|
         f << %(var I18n = I18n || {};\n)

--- a/lib/i18n-js/engine.rb
+++ b/lib/i18n-js/engine.rb
@@ -31,7 +31,7 @@ module SimplesIdeias
       # rewrite path cache hash at startup and before each request in development
       config.to_prepare do
         next unless SimplesIdeias::I18n.has_asset_pipeline?
-        SimplesIdeias::I18n::Engine.write_hash_if_changed unless Rails.env.production?
+        SimplesIdeias::I18n::Engine.write_hash_if_changed if Rails.env.development?
       end
 
       def self.load_path_hash_cache


### PR DESCRIPTION
This pr fixes a bug whereby, if you're using assets pipeline with digest = true, the digest of the resulting `application.js` are different on different servers.

 I found out it was because the order of the generated translations hash keys could be different. That would programmatically not be a problem but it's a problem when generating an md5 of the content.

 So sorting the hash before saving to a file would make sure it's always the same content all the time, resulting in a consistent hashing on different servers.

Thanks
